### PR TITLE
Fix: Explicitly set build input and use relative script path

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,6 @@
 <body>
   <noscript>You need to enable JavaScript to run this app.</noscript>
   <div id="root"></div>
-  <script type="module" src="/index.tsx"></script>
+  <script type="module" src="./index.tsx"></script>
 </body>
 </html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,11 @@ export default defineConfig(({ mode }) => {
         alias: {
           '@': path.resolve(__dirname, '.'),
         }
+      },
+      build: {
+        rollupOptions: {
+          input: 'index.html'
+        }
       }
     };
 });


### PR DESCRIPTION
- Modified `vite.config.ts` to explicitly set `build.rollupOptions.input` to `'index.html'`. This is to ensure Vite/Rollup correctly processes the main HTML file and transforms script tags for production.
- Changed the script `src` in the root `index.html` back to `./index.tsx` to ensure consistent entry point resolution.

These changes aim to resolve an issue where the deployed `index.html` on GitHub Pages was not referencing the compiled JavaScript assets correctly, leading to MIME type or 404 errors.