### PR TITLE
Feat: Restructure Vite entry point to src/main.tsx

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,6 @@
 <body>
   <noscript>You need to enable JavaScript to run this app.</noscript>
   <div id="root"></div>
-  <script type="module" src="/index.tsx"></script>
+  <script type="module" src="/src/main.tsx"></script>
 </body>
 </html>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { App } from './App';
-import 'src/index.css'; // Add this line
+import { App } from '../App';
+import './index.css'; // Add this line
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,11 @@ export default defineConfig(({ mode }) => {
         alias: {
           '@': path.resolve(__dirname, '.'),
         }
+      },
+      build: {
+        rollupOptions: {
+          input: 'index.html'
+        }
       }
     };
 });


### PR DESCRIPTION
- I moved the main application entry point from `index.tsx` (in root) to `src/main.tsx`.
- I updated the script tag in the root `index.html` to `src="/src/main.tsx"`.
- I adjusted import paths within `src/main.tsx` to reflect its new location relative to `App.tsx` and `src/index.css`.
- I removed the original `index.tsx` from the project root.

This restructuring aligns your project with common Vite conventions and aims to resolve a persistent issue where the Vite build process was not correctly transforming the script reference in `index.html` for deployment, leading to MIME type errors on GitHub Pages.