### PR TITLE
Fix: Simplify index.html to minimal version for testing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,17 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Tabletop Game Engine</title>
-  <style>
-    body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; overflow: hidden; }
-    .no-select { user-select: none; -webkit-user-select: none; -moz-user-select: none; -ms-user-select: none; }
-  </style>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Vite App Test</title>
 </head>
 <body>
-  <noscript>You need to enable JavaScript to run this app.</noscript>
   <div id="root"></div>
-  <script type="module" src="/index.tsx"></script>
+  <script type="module" src="/src/main.tsx"></script>
 </body>
 </html>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { App } from './App';
-import 'src/index.css'; // Add this line
+import { App } from '../App';
+import './index.css'; // Add this line
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,11 @@ export default defineConfig(({ mode }) => {
         alias: {
           '@': path.resolve(__dirname, '.'),
         }
+      },
+      build: {
+        rollupOptions: {
+          input: 'index.html'
+        }
       }
     };
 });


### PR DESCRIPTION
Replaced the content of the root `index.html` with a bare-minimum HTML structure. This change is to test whether Vite's HTML processing is fundamentally failing for this project or if the issue was with the previous content/structure of `index.html`.

Confirmed that `vite.config.ts` does not have a `publicDir` misconfiguration that would cause `index.html` to be copied without processing.